### PR TITLE
Remove deprecated 'problems' key from config

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,15 +4,6 @@
   "repository": "https://github.com/exercism/xbash",
   "checklist_issue": 4,
   "active": false,
-  "problems": [
-    "hello-world",
-    "gigasecond",
-    "leap",
-    "hamming",
-    "rna-transcription",
-    "raindrops",
-    "bob"
-  ],
   "exercises": [
     {
       "slug": "hello-world" ,


### PR DESCRIPTION
The API now handles looking at the new key, so we can remove the old one.